### PR TITLE
fixed(strdup): use common/url.{h,c} to not include strdup everywhere.

### DIFF
--- a/src/clib-search.c
+++ b/src/clib-search.c
@@ -10,6 +10,7 @@
 #include "commander/commander.h"
 #include "common/clib-cache.h"
 #include "common/clib-package.h"
+#include "common/url.h"
 #include "console-colors/console-colors.h"
 #include "debug/debug.h"
 #include "fs/fs.h"
@@ -26,7 +27,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <url/url.h>
 #include "clib-settings.h"
 
 #define CLIB_SEARCH_CACHE_TIME 1 * 24 * 60 * 60

--- a/src/common/url.c
+++ b/src/common/url.c
@@ -1,5 +1,6 @@
-#define URL_H_IMPLEMENTATION
-#include "url/url.h"
+#ifndef URL_H
 
-// This is a bit of a hack to use url.h in multiple files.
-// It is better if we just split url.h
+#define URL_H_IMPLEMENTATION
+#include "url.h"
+
+#endif

--- a/src/common/url.h
+++ b/src/common/url.h
@@ -1,0 +1,9 @@
+#ifndef URL_H
+
+// use this proxy file to avoid adding strdup
+// everytime a file requires url.
+
+#include <strdup/strdup.h> // for HAVE_STRDUP
+#include <url/url.h>
+
+#endif

--- a/src/registry/registry-manager.c
+++ b/src/registry/registry-manager.c
@@ -6,7 +6,7 @@
 //
 #include "registry-manager.h"
 #include <stdlib.h>
-#include "url/url.h"
+#include "../common/url.h"
 
 #define CLIB_WIKI_URL "https://github.com/clibs/clib/wiki/Packages"
 

--- a/src/registry/registry.c
+++ b/src/registry/registry.c
@@ -10,7 +10,7 @@
 #include "gumbo-parser/gumbo.h"
 #include "list/list.h"
 #include "registry-internal.h"
-#include "url/url.h"
+#include "../common/url.h"
 #include <logger/logger.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/repository/gitlab-repository.c
+++ b/src/repository/gitlab-repository.c
@@ -5,10 +5,10 @@
 // MIT licensed
 //
 #include "gitlab-repository.h"
+#include "../common/url.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <url/url.h>
 
 #define GITLAB_API_V4_URL "https://%s/api/v4%s/repository/files/%s/raw?ref=master"
 

--- a/src/repository/repository.c
+++ b/src/repository/repository.c
@@ -10,6 +10,7 @@
 #include "debug/debug.h"
 #include "github-repository.h"
 #include "gitlab-repository.h"
+#include "../common/url.h"
 #include <clib-package.h>
 #include <clib-secrets.h>
 #include <fs/fs.h>
@@ -18,7 +19,6 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
-#include <url/url.h>
 
 static debug_t _debugger;
 #define _debug(...)                              \


### PR DESCRIPTION
This can be applied when/if the [patch to url.h](https://github.com/jwerle/url.h/pull/8) is merged. 

Hope this helps. 👍 